### PR TITLE
guard snooze from nil

### DIFF
--- a/tuido/tuido.go
+++ b/tuido/tuido.go
@@ -140,6 +140,10 @@ func (i *Item) SetText(t string) error {
 }
 
 func (i *Item) Snooze() error {
+	if i == nil {
+		return fmt.Errorf("item is nil - cannot snooze")
+	}
+
 	count := i.snoozeCount()
 	count++
 


### PR DESCRIPTION
While checking out the tool, I encountered: 
```
Caught panic:

runtime error: invalid memory address or nil pointer dereference

Restoring terminal...

goroutine 1 [running]:
runtime/debug.Stack()
	/opt/hostedtoolcache/go/1.18.5/x64/src/runtime/debug/stack.go:24 +0x65
runtime/debug.PrintStack()
	/opt/hostedtoolcache/go/1.18.5/x64/src/runtime/debug/stack.go:16 +0x19
github.com/charmbracelet/bubbletea.(*Program).StartReturningModel.func3()
	/home/runner/go/pkg/mod/github.com/charmbracelet/bubbletea@v0.20.0/tea.go:359 +0x95
panic({0x516ba0, 0x627d60})
	/opt/hostedtoolcache/go/1.18.5/x64/src/runtime/panic.go:844 +0x258
github.com/nilock/tuido/tuido.(*Item).snoozeCount(0x3?)
	/home/runner/work/tuido/tuido/tuido/tuido.go:185 +0x18
github.com/nilock/tuido/tuido.(*Item).Snooze(0xc0001cef00?)
	/home/runner/work/tuido/tuido/tuido/tuido.go:143 +0x25
github.com/nilock/tuido/tui.tui.Update({{{0x628a40, 0x3, 0x3}, {0xc0000e60a8, 0x13}}, {0xc00010e720, 0x3, 0x4}, {0x53296d, 0x4}, ...}, ...)
	/home/runner/work/tuido/tuido/tui/update.go:162 +0x1177
github.com/charmbracelet/bubbletea.(*Program).StartReturningModel(0xc0000ea180)
	/home/runner/go/pkg/mod/github.com/charmbracelet/bubbletea@v0.20.0/tea.go:547 +0x1351
github.com/charmbracelet/bubbletea.(*Program).Start(...)
	/home/runner/go/pkg/mod/github.com/charmbracelet/bubbletea@v0.20.0/tea.go:556
github.com/nilock/tuido/tui.Run()
	/home/runner/work/tuido/tuido/tui/tui.go:58 +0x451
main.main()
	/home/runner/work/tuido/tuido/main.go:8 +0x17
```

This fixes it.


P.S: if you want to repeat the panic, the simplest way is to open an empty todo list and press `z`.
