### PR TITLE
fix: prevent nil pointers for edit/escalate/deescalate (empty tab)

### DIFF
--- a/tui/tui.go
+++ b/tui/tui.go
@@ -227,10 +227,12 @@ func (t *tui) setPeekMode() tea.Cmd {
 }
 
 func (t *tui) setEditMode() tea.Cmd {
-	t.mode = edit
-	t.itemEditor.SetValue(t.currentSelection().Text())
-	t.itemEditor.CursorEnd()
-	t.itemEditor.Focus()
+	if t.currentSelection() != nil {
+		t.mode = edit
+		t.itemEditor.SetValue(t.currentSelection().Text())
+		t.itemEditor.CursorEnd()
+		t.itemEditor.Focus()
+	}
 	return nil
 }
 

--- a/tui/update.go
+++ b/tui/update.go
@@ -157,7 +157,9 @@ func (t tui) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "/":
 			t.filter.Focus()
 		case "p":
-			t.setPomoMode()
+			if t.currentSelection() != nil {
+				t.setPomoMode()
+			}
 		case "?":
 			t.mode = help
 		// editing current selection
@@ -176,21 +178,25 @@ func (t tui) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case " ":
 			t.currentSelection().SetStatus(tuido.Open)
 		case "!":
-			current := t.currentSelection()
-			t.currentSelection().Escalate()
-			t.populateRenderSelection()
-			for i, item := range t.renderSelection {
-				if current == item {
-					t.setSelection(i)
+			if t.currentSelection() != nil {
+				current := t.currentSelection()
+				t.currentSelection().Escalate()
+				t.populateRenderSelection()
+				for i, item := range t.renderSelection {
+					if current == item {
+						t.setSelection(i)
+					}
 				}
 			}
 		case "1":
-			current := t.currentSelection()
-			t.currentSelection().Deescalate()
-			t.populateRenderSelection()
-			for i, item := range t.renderSelection {
-				if current == item {
-					t.setSelection(i)
+			if t.currentSelection() != nil {
+				current := t.currentSelection()
+				t.currentSelection().Deescalate()
+				t.populateRenderSelection()
+				for i, item := range t.renderSelection {
+					if current == item {
+						t.setSelection(i)
+					}
 				}
 			}
 		case "e":


### PR DESCRIPTION
fix: prevent nil pointers for edit/escalate/deescalate when the tab is empty and no item is selected