### PR TITLE
fix slice oob err while peeking items on last line

### DIFF
--- a/tuido/tuido.go
+++ b/tuido/tuido.go
@@ -204,8 +204,13 @@ func (i *Item) GetContext(height int) (string, int) {
 	}
 
 	preItemLines := strings.Join(lines[first:i.line], "\n")
+
 	item := lines[i.line]
-	postItemLines := strings.Join(lines[i.line+1:last], "\n")
+
+	postItemLines := ""
+	if (i.line + 1) < last {
+		postItemLines = strings.Join(lines[i.line+1:last], "\n")
+	}
 
 	item = lipgloss.NewStyle().Bold(true).Italic(true).Render(item) // not working - clobbered by styles from chroma
 

--- a/utils/versioning.go
+++ b/utils/versioning.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-const version = "v0.0.8"
+const version = "v0.0.9"
 const ReleaseURL = "https://github.com/NiloCK/tuido/releases/latest"
 
 // Version returns the currently running version of the application.


### PR DESCRIPTION
closes #16 

Crash was for peeking an item on last line - not the empty text.